### PR TITLE
Updates the library to include both the concept of HTTP routes and TCP

### DIFF
--- a/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPCreateRequest.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPCreateRequest.java
@@ -22,10 +22,7 @@ import java.util.Map;
 
 import org.cloudfoundry.receptor.actions.Action;
 import org.cloudfoundry.receptor.actions.RunAction;
-import org.cloudfoundry.receptor.support.EgressRule;
-import org.cloudfoundry.receptor.support.EnvironmentVariable;
-import org.cloudfoundry.receptor.support.ModificationTag;
-import org.cloudfoundry.receptor.support.Route;
+import org.cloudfoundry.receptor.support.*;
 
 import org.springframework.util.ObjectUtils;
 
@@ -37,6 +34,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * @author Mark Fisher
+ * @author Matt Stine
  */
 public class DesiredLRPCreateRequest {
 
@@ -78,6 +76,7 @@ public class DesiredLRPCreateRequest {
 
 	private int[] ports = new int[] { 8080 };
 
+	@JsonDeserialize(using = RouteMapSerializer.class)
 	private Map<String, Route[]> routes = new HashMap<String, Route[]>();
 
 	@JsonProperty("log_guid")
@@ -229,8 +228,12 @@ public class DesiredLRPCreateRequest {
 		this.routes = routes;
 	}
 
-	public void addRoute(int port, String... hostnames) {
-		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new Route(port, hostnames)));
+	public void addHttpRoute(int port, String... hostnames) {
+		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new HttpRoute(port, hostnames)));
+	}
+
+	public void addTcpRoute(int externalPort, int containerPort) {
+		this.routes.put("tcp-router", ObjectUtils.addObjectToArray(this.routes.get("tcp-router"), new TcpRoute(externalPort, containerPort)));
 	}
 
 	public String getLogGuid() {

--- a/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPCreateRequest.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPCreateRequest.java
@@ -76,7 +76,7 @@ public class DesiredLRPCreateRequest {
 
 	private int[] ports = new int[] { 8080 };
 
-	@JsonDeserialize(using = RouteMapSerializer.class)
+	@JsonDeserialize(using = RouteMapDeserializer.class)
 	private Map<String, Route[]> routes = new HashMap<String, Route[]>();
 
 	@JsonProperty("log_guid")

--- a/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPUpdateRequest.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPUpdateRequest.java
@@ -33,7 +33,7 @@ public class DesiredLRPUpdateRequest {
 
 	private int instances = 1;
 
-	@JsonDeserialize(using = RouteMapSerializer.class)
+	@JsonDeserialize(using = RouteMapDeserializer.class)
 	private Map<String, Route[]> routes = new HashMap<String, Route[]>();
 
 	private String annotation;
@@ -59,7 +59,7 @@ public class DesiredLRPUpdateRequest {
 	}
 
 	public void addTcpRoute(int externalPort, int containerPort) {
-		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new TcpRoute(externalPort, containerPort)));
+		this.routes.put("tcp-router", ObjectUtils.addObjectToArray(this.routes.get("tcp-router"), new TcpRoute(externalPort, containerPort)));
 	}
 
 	public void setAnnotation(String annotation) {

--- a/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPUpdateRequest.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/DesiredLRPUpdateRequest.java
@@ -19,16 +19,21 @@ package org.cloudfoundry.receptor.commands;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.cloudfoundry.receptor.support.HttpRoute;
 import org.cloudfoundry.receptor.support.Route;
+import org.cloudfoundry.receptor.support.TcpRoute;
 import org.springframework.util.ObjectUtils;
 
 /**
  * @author Mark Fisher
+ * @author Matt Stine
  */
 public class DesiredLRPUpdateRequest {
 
 	private int instances = 1;
 
+	@JsonDeserialize(using = RouteMapSerializer.class)
 	private Map<String, Route[]> routes = new HashMap<String, Route[]>();
 
 	private String annotation;
@@ -49,8 +54,12 @@ public class DesiredLRPUpdateRequest {
 		this.routes = routes;
 	}
 
-	public void addRoute(int port, String... hostnames) {
-		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new Route(port, hostnames)));
+	public void addHttpRoute(int port, String... hostnames) {
+		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new HttpRoute(port, hostnames)));
+	}
+
+	public void addTcpRoute(int externalPort, int containerPort) {
+		this.routes.put("cf-router", ObjectUtils.addObjectToArray(this.routes.get("cf-router"), new TcpRoute(externalPort, containerPort)));
 	}
 
 	public void setAnnotation(String annotation) {

--- a/src/main/java/org/cloudfoundry/receptor/commands/RouteMapDeserializer.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/RouteMapDeserializer.java
@@ -18,7 +18,7 @@ import java.util.Map;
 /**
  * @author Matt Stine
  */
-public class RouteMapSerializer extends JsonDeserializer<Map<String, Route[]>> {
+public class RouteMapDeserializer extends JsonDeserializer<Map<String, Route[]>> {
     @Override
     public Map<String, Route[]> deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
         ObjectCodec codec = parser.getCodec();

--- a/src/main/java/org/cloudfoundry/receptor/commands/RouteMapSerializer.java
+++ b/src/main/java/org/cloudfoundry/receptor/commands/RouteMapSerializer.java
@@ -1,0 +1,55 @@
+package org.cloudfoundry.receptor.commands;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.cloudfoundry.receptor.support.HttpRoute;
+import org.cloudfoundry.receptor.support.Route;
+import org.cloudfoundry.receptor.support.TcpRoute;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * @author Matt Stine
+ */
+public class RouteMapSerializer extends JsonDeserializer<Map<String, Route[]>> {
+    @Override
+    public Map<String, Route[]> deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
+        ObjectCodec codec = parser.getCodec();
+        Map<String, Route[]> map = new HashMap<>();
+        final JsonNode node = codec.readTree(parser);
+
+        if (node.has("cf-router")) {
+            deserializeRouteArray("cf-router", codec, map, node, HttpRoute.class);
+        }
+
+        if (node.has("tcp-router")) {
+            deserializeRouteArray("tcp-router", codec, map, node, TcpRoute.class);
+        }
+
+        return (map.size() == 0) ? null : map;
+    }
+
+    private void deserializeRouteArray(String basePath, ObjectCodec codec, Map<String, Route[]> map, JsonNode node, Class<? extends Route> type) throws IOException {
+        final JsonNode baseNode = node.path(basePath);
+
+        Route[] routes = new Route[baseNode.size()];
+        final Iterator<JsonNode> routeNodes = baseNode.elements();
+
+        int i = 0;
+        while (routeNodes.hasNext()) {
+            JsonNode route = routeNodes.next();
+            routes[i] = route.traverse(codec).readValueAs(type);
+            i++;
+        }
+
+        map.put(basePath, routes);
+    }
+
+}

--- a/src/main/java/org/cloudfoundry/receptor/support/HttpRoute.java
+++ b/src/main/java/org/cloudfoundry/receptor/support/HttpRoute.java
@@ -1,0 +1,42 @@
+package org.cloudfoundry.receptor.support;
+
+import java.util.Arrays;
+
+/**
+ * @author Mark Fisher
+ * @author Matt Stine
+ */
+public class HttpRoute implements Route {
+    private String[] hostnames;
+    private int port;
+
+    public HttpRoute() {
+    }
+
+    public HttpRoute(int port, String... hostnames) {
+        this.port = port;
+        this.hostnames = hostnames;
+    }
+
+    public String[] getHostnames() {
+        return hostnames;
+    }
+
+    public void setHostnames(String... hostnames) {
+        this.hostnames = hostnames;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpRoute [hostnames=" + Arrays.toString(hostnames) + ", port="
+                + port + "]";
+    }
+}

--- a/src/main/java/org/cloudfoundry/receptor/support/Route.java
+++ b/src/main/java/org/cloudfoundry/receptor/support/Route.java
@@ -16,44 +16,9 @@
 
 package org.cloudfoundry.receptor.support;
 
-import java.util.Arrays;
-
 /**
  * @author Mark Fisher
+ * @author Matt Stine
  */
-public class Route {
-
-	private String[] hostnames;
-
-	private int port;
-
-	@SuppressWarnings("unused")
-	private Route() {}
-
-	public Route(int port, String... hostnames) {
-		this.port = port;
-		this.hostnames = hostnames;
-	}
-
-	public String[] getHostnames() {
-		return hostnames;
-	}
-
-	public void setHostnames(String... hostnames) {
-		this.hostnames = hostnames;
-	}
-
-	public int getPort() {
-		return port;
-	}
-
-	public void setPort(int port) {
-		this.port = port;
-	}
-
-	@Override
-	public String toString() {
-		return "Route [hostnames=" + Arrays.toString(hostnames) + ", port="
-				+ port + "]";
-	}
+public interface Route {
 }

--- a/src/main/java/org/cloudfoundry/receptor/support/TcpRoute.java
+++ b/src/main/java/org/cloudfoundry/receptor/support/TcpRoute.java
@@ -1,0 +1,45 @@
+package org.cloudfoundry.receptor.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Matt Stine
+ */
+public class TcpRoute implements Route {
+
+    @JsonProperty("external_port")
+    private int externalPort;
+
+    @JsonProperty("container_port")
+    private int containerPort;
+
+    public TcpRoute() {
+    }
+
+    public TcpRoute(int externalPort, int port) {
+        this.externalPort = externalPort;
+        this.containerPort = port;
+    }
+
+    public int getExternalPort() {
+        return externalPort;
+    }
+
+    public void setExternalPort(int externalPort) {
+        this.externalPort = externalPort;
+    }
+
+    public int getContainerPort() {
+        return containerPort;
+    }
+
+    public void setContainerPort(int containerPort) {
+        this.containerPort = containerPort;
+    }
+
+    @Override
+    public String toString() {
+        return "TcpRoute [externalPort=" + externalPort + ", containerPort="
+                + containerPort + "]";
+    }
+}

--- a/src/test/java/org/cloudfoundry/receptor/client/ReceptorClientIntegrationTests.java
+++ b/src/test/java/org/cloudfoundry/receptor/client/ReceptorClientIntegrationTests.java
@@ -32,11 +32,13 @@ import org.cloudfoundry.receptor.commands.CellResponse;
 import org.cloudfoundry.receptor.commands.DesiredLRPCreateRequest;
 import org.cloudfoundry.receptor.commands.DesiredLRPResponse;
 import org.cloudfoundry.receptor.commands.TaskCreateRequest;
+import org.cloudfoundry.receptor.support.EnvironmentVariable;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
  * @author Mark Fisher
+ * @author Matt Stine
  */
 @Category(IntegrationTest.class)
 public class ReceptorClientIntegrationTests {
@@ -44,6 +46,8 @@ public class ReceptorClientIntegrationTests {
 	private static final Log logger = LogFactory.getLog(ReceptorClientIntegrationTests.class);
 
 	private static final String APP_DOCKER_PATH = "docker:///cloudfoundry/lattice-app";
+
+	private static final String MYSQL_DOCKER_PATH = "docker:///mysql";
 
 	private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -58,7 +62,58 @@ public class ReceptorClientIntegrationTests {
 		request.setProcessGuid(processGuid);
 		request.setRootfs(APP_DOCKER_PATH);
 		request.runAction().setPath("/lattice-app");
-		request.addRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
+		request.addHttpRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
+		request.setDomain("yomamma");
+		logger.info("creating LRP: " + objectMapper.writeValueAsString(request));
+		client.createDesiredLRP(request);
+
+		boolean desiredLrpExists = false;
+		for (DesiredLRPResponse desiredLRPResponse : client.getDesiredLRPs()) {
+			if(desiredLRPResponse.getProcessGuid().equals(processGuid)) {
+				desiredLrpExists = true;
+				break;
+			}
+		}
+
+		assertTrue(desiredLrpExists);
+
+		boolean actualLrpExists = false;
+		for (ActualLRPResponse actualLRPResponse : client.getActualLRPs()) {
+			if(actualLRPResponse.getProcessGuid().equals(processGuid)) {
+				actualLrpExists = true;
+				break;
+			}
+		}
+
+		assertTrue(actualLrpExists);
+
+		client.deleteDesiredLRP(processGuid);
+		for (int i = 0; i < 1000; i++) {
+			Thread.sleep(100);
+			if (0 == client.getActualLRPsByProcessGuid(processGuid).size()) {
+				break;
+			}
+		}
+		assertEquals(desiredLrpCountAtStart, client.getDesiredLRPs().size());
+		assertEquals(actualLrpCountAtStart, client.getActualLRPs().size());
+	}
+
+	@Test
+	public void createAndDeleteLRPWithTcpRoute() throws Exception {
+		int desiredLrpCountAtStart = client.getDesiredLRPs().size();
+		int actualLrpCountAtStart = client.getActualLRPs().size();
+		DesiredLRPCreateRequest request = new DesiredLRPCreateRequest();
+		String processGuid = UUID.randomUUID().toString();
+		request.setProcessGuid(processGuid);
+		request.setRootfs(MYSQL_DOCKER_PATH);
+		request.setPorts(new int[]{3306});
+		request.setEnv(new EnvironmentVariable[]{new EnvironmentVariable("MYSQL_ROOT_PASSWORD", "somesecret")});
+		request.runAction().setPath("/entrypoint.sh");
+		request.runAction().addArg("mysqld");
+		request.runAction().setUser("root");
+		request.addTcpRoute(3306, 3306);
+		request.setPriviliged(true);
+		request.setMemoryMb(512);
 		request.setDomain("yomamma");
 		logger.info("creating LRP: " + objectMapper.writeValueAsString(request));
 		client.createDesiredLRP(request);

--- a/src/test/java/org/cloudfoundry/receptor/client/ReceptorClientTests.java
+++ b/src/test/java/org/cloudfoundry/receptor/client/ReceptorClientTests.java
@@ -57,6 +57,7 @@ import org.springframework.web.client.RestOperations;
 /**
  * @author Michael Minella
  * @author Mark Fisher
+ * @author Matt Stine
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ReceptorClientTests {
@@ -93,8 +94,23 @@ public class ReceptorClientTests {
 	}
 
 	@Test
+	public void testCreateDesiredLRPWithTcpRoute() throws Exception {
+		ArgumentCaptor<DesiredLRPCreateRequest> requestCaptor = ArgumentCaptor.forClass(DesiredLRPCreateRequest.class);
+
+		DesiredLRPCreateRequest request = getDesiredLRPCreateRequestWithTcpRoute();
+
+		receptorClient.createDesiredLRP(request);
+
+		verify(restTemplate).postForEntity(eq("{baseUrl}/desired_lrps"), requestCaptor.capture(), (Class) isNull(), eq(BASE_URL));
+		verifyNoMoreInteractions(restTemplate);
+
+		DesiredLRPCreateRequest receivedRequest = (DesiredLRPCreateRequest) requestCaptor.getValue();
+		assertDesiredLRPRequest(receivedRequest);
+	}
+
+	@Test
 	public void testGetDesiredLRP() {
-		ResponseEntity<DesiredLRPResponse> entity = new ResponseEntity(getDesiredLRPResponse(), HttpStatus.OK);
+		ResponseEntity<DesiredLRPResponse> entity = new ResponseEntity(getDesiredLRPResponseWithTcpRoute(), HttpStatus.OK);
 
 		when(restTemplate.exchange("{baseUrl}/desired_lrps/{processGuid}", HttpMethod.GET, null, DesiredLRPResponse.class, BASE_URL, "123")).thenReturn(entity);
 
@@ -394,7 +410,7 @@ public class ReceptorClientTests {
 		request.setProcessGuid("test-app");
 		request.setRootfs(APP_DOCKER_PATH);
 		request.runAction().setPath("/lattice-app");
-		request.addRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
+		request.addHttpRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
 		return request;
 	}
 
@@ -403,7 +419,25 @@ public class ReceptorClientTests {
 		response.setProcessGuid("123");
 		response.setRootfs(APP_DOCKER_PATH);
 		response.runAction().setPath("/lattice-app");
-		response.addRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
+		response.addHttpRoute(8080, "test-app.192.168.11.11.xip.io", "test-app-8080.192.168.11.11.xip.io");
+		return response;
+	}
+
+	private DesiredLRPCreateRequest getDesiredLRPCreateRequestWithTcpRoute() {
+		DesiredLRPCreateRequest request = new DesiredLRPCreateRequest();
+		request.setProcessGuid("test-app");
+		request.setRootfs(APP_DOCKER_PATH);
+		request.runAction().setPath("/lattice-app");
+		request.addTcpRoute(8080, 8080);
+		return request;
+	}
+
+	private DesiredLRPResponse getDesiredLRPResponseWithTcpRoute() {
+		DesiredLRPResponse response = new DesiredLRPResponse();
+		response.setProcessGuid("123");
+		response.setRootfs(APP_DOCKER_PATH);
+		response.runAction().setPath("/lattice-app");
+		response.addTcpRoute(8080, 8080);
 		return response;
 	}
 


### PR DESCRIPTION
routes.

* Route is now an interface, implemented by HttpRoute and TcpRoute.
* RouteMapSerializer deals with the distinction based on key ('cf-router' or 'tcp-router')
* DesiredLRPCreate/UpdateRequest now have addHttpRoute and addTcpRoute methods
* Tests updated to deal with both types of routes